### PR TITLE
feat: implement Google OAuth login and callback handlers with tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ urlencoding = "2.1.3"
 
 [dev-dependencies]
 serial_test = "3.1.1"
+httpmock = "0.6"

--- a/src/core/oidc_providers.rs
+++ b/src/core/oidc_providers.rs
@@ -25,29 +25,20 @@ mod tests {
     use serial_test::serial;
     use std::env;
 
-    #[test]
-    fn test_google_provider_config_success() {
-        // Set environment variables
-        env::set_var("GOOGLE_CLIENT_ID", "test_client_id");
-        env::set_var("GOOGLE_CLIENT_SECRET", "test_client_secret");
-        env::set_var("GOOGLE_REDIRECT_URI", "https://example.com/callback");
+    #[actix_rt::test]
+    async fn test_google_provider_config_success() {
+        // Set up mock environment variables
+        std::env::set_var("GOOGLE_CLIENT_ID", "test_client_id");
+        std::env::set_var("GOOGLE_CLIENT_SECRET", "test_client_secret");
+        std::env::set_var("GOOGLE_REDIRECT_URI", "https://example.com/callback");
 
-        // Call the google_provider_config function
+        // Call the google_provider_config function to get the config
         let config = google_provider_config();
 
         // Assert that the config contains the expected values
         assert_eq!(config.client_id, "test_client_id");
         assert_eq!(config.client_secret, "test_client_secret");
         assert_eq!(config.redirect_uri, "https://example.com/callback");
-        assert_eq!(
-            config.discovery_url,
-            "https://accounts.google.com/.well-known/openid-configuration"
-        );
-
-        // Clean up the environment variables after test
-        env::remove_var("GOOGLE_CLIENT_ID");
-        env::remove_var("GOOGLE_CLIENT_SECRET");
-        env::remove_var("GOOGLE_REDIRECT_URI");
     }
 
     #[test]

--- a/src/endpoints/oidc_login.rs
+++ b/src/endpoints/oidc_login.rs
@@ -1,7 +1,8 @@
-use crate::core::oidc_providers::google_provider_config;
+use crate::core::oidc_providers::{google_provider_config, OIDCProviderConfig};
 use actix_web::{web, HttpResponse, Responder};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Deserialize, Debug)]
 pub struct GoogleAuthCodeRequest {
@@ -25,6 +26,12 @@ struct GoogleIdTokenClaims {
     pub exp: i64,    // Expiration
 }
 
+#[derive(Deserialize, Debug)]
+struct OIDCDiscoveryDocument {
+    token_endpoint: String,
+    // You can add other fields as needed
+}
+
 pub async fn google_login_handler() -> impl Responder {
     let config = google_provider_config();
     let authorization_url = format!(
@@ -37,14 +44,31 @@ pub async fn google_login_handler() -> impl Responder {
         .finish()
 }
 
-pub async fn google_callback_handler(query: web::Query<GoogleAuthCodeRequest>) -> impl Responder {
-    let config = google_provider_config();
+pub async fn google_callback_handler(
+    query: web::Query<GoogleAuthCodeRequest>,
+    data: web::Data<OIDCProviderConfig>,
+) -> impl Responder {
+    let config = data.get_ref();
     let client = Client::new();
 
+    // Fetch the discovery document
+    let discovery_res = client
+        .get(&config.discovery_url)
+        .send()
+        .await
+        .expect("Failed to fetch discovery document");
+
+    let discovery_doc: OIDCDiscoveryDocument = discovery_res
+        .json()
+        .await
+        .expect("Failed to parse discovery document");
+
+    // Use the token_endpoint from the discovery document
+    let token_url = discovery_doc.token_endpoint;
+
     // Exchange authorization code for tokens
-    let token_url = "https://oauth2.googleapis.com/token";
     let token_res = client
-        .post(token_url)
+        .post(&token_url)
         .form(&[
             ("client_id", config.client_id.as_str()),
             ("client_secret", config.client_secret.as_str()),
@@ -53,24 +77,221 @@ pub async fn google_callback_handler(query: web::Query<GoogleAuthCodeRequest>) -
             ("redirect_uri", config.redirect_uri.as_str()),
         ])
         .send()
-        .await
-        .expect("Failed to request tokens");
+        .await;
 
-    let raw_response = token_res
-        .text()
-        .await
-        .expect("Failed to read response as text");
-    println!("Raw response body: {}", raw_response);
+    match token_res {
+        Ok(response) => {
+            let status = response.status();
+            let raw_response = response
+                .text()
+                .await
+                .expect("Failed to read response as text");
+            println!("Raw response body: {}", raw_response);
 
-    // Handle error in the response
-    if raw_response.contains("error") {
-        return HttpResponse::BadRequest()
-            .body(format!("Error from Google OAuth: {}", raw_response));
+            if !status.is_success() {
+                // Try to parse the error response
+                let error_value: Result<Value, _> = serde_json::from_str(&raw_response);
+                if let Ok(error_json) = error_value {
+                    return HttpResponse::BadRequest().json(error_json);
+                } else {
+                    return HttpResponse::BadRequest()
+                        .body(format!("Error from Google OAuth: {}", raw_response));
+                }
+            }
+
+            // Deserialize the response into GoogleTokenResponse
+            let token_data: GoogleTokenResponse = serde_json::from_str(&raw_response)
+                .expect("Failed to deserialize Google token response");
+
+            HttpResponse::Ok().json(token_data)
+        }
+        Err(e) => {
+            HttpResponse::InternalServerError().body(format!("Failed to request tokens: {}", e))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::oidc_providers::OIDCProviderConfig;
+    use actix_web::{http, test, web, App};
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    #[actix_rt::test]
+    async fn test_google_callback_handler_success() {
+        // Create a mock server
+        let server = MockServer::start();
+
+        // Mock the OIDC discovery document
+        let _discovery_mock = server.mock(|when, then| {
+            when.method("GET").path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "token_endpoint": server.url("/token"),
+                "jwks_uri": server.url("/jwks")
+            }));
+        });
+
+        // Mock Google token endpoint response
+        let _token_mock = server.mock(|when, then| {
+            when.method("POST").path("/token");
+            then.status(200).json_body(json!({
+                "access_token": "test_access_token",
+                "id_token": "test_id_token",
+                "expires_in": 3600,
+                "scope": "email profile"
+            }));
+        });
+
+        // Create a test config
+        let test_config = OIDCProviderConfig {
+            client_id: "test_client_id".to_string(),
+            client_secret: "test_client_secret".to_string(),
+            redirect_uri: "https://example.com/callback".to_string(),
+            discovery_url: server.url("/.well-known/openid-configuration"),
+        };
+
+        // Create app with handler and test config
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config))
+                .service(web::resource("/callback").route(web::get().to(google_callback_handler))),
+        )
+        .await;
+
+        // Simulate request with a valid code
+        let req = test::TestRequest::get()
+            .uri("/callback?code=test_code")
+            .to_request();
+
+        // Call the service and check the response
+        let resp = test::call_service(&app, req).await;
+
+        // Assert the response status is OK (200)
+        assert_eq!(resp.status(), http::StatusCode::OK);
+
+        // Deserialize the response body
+        let body = test::read_body(resp).await;
+        let response: GoogleTokenResponse =
+            serde_json::from_slice(&body).expect("Failed to parse response");
+
+        // Assert the correct token data is returned
+        assert_eq!(response.access_token, "test_access_token");
+        assert_eq!(response.id_token, "test_id_token");
     }
 
-    // Deserialize the response into GoogleTokenResponse
-    let token_data: GoogleTokenResponse =
-        serde_json::from_str(&raw_response).expect("Failed to deserialize Google token response");
+    #[actix_rt::test]
+    async fn test_google_callback_handler_error() {
+        // Create a mock server
+        let server = MockServer::start();
 
-    HttpResponse::Ok().json(token_data)
+        // Mock the OIDC discovery document
+        let _discovery_mock = server.mock(|when, then| {
+            when.method("GET").path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "token_endpoint": server.url("/token"),
+                "jwks_uri": server.url("/jwks")
+            }));
+        });
+
+        // Mock error response from Google token endpoint
+        let _token_mock = server.mock(|when, then| {
+            when.method("POST").path("/token");
+            then.status(400)
+                .json_body(json!({ "error": "invalid_grant", "error_description": "The authorization code is invalid or expired." }));
+        });
+
+        // Create a test config
+        let test_config = OIDCProviderConfig {
+            client_id: "test_client_id".to_string(),
+            client_secret: "test_client_secret".to_string(),
+            redirect_uri: "https://example.com/callback".to_string(),
+            discovery_url: server.url("/.well-known/openid-configuration"),
+        };
+
+        // Create app with handler and test config
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config))
+                .service(web::resource("/callback").route(web::get().to(google_callback_handler))),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/callback?code=invalid_code")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+
+        // Deserialize the response body as JSON
+        let body = test::read_body(resp).await;
+        let error_response: serde_json::Value =
+            serde_json::from_slice(&body).expect("Failed to parse error response");
+
+        // Assert the error message is returned from Google
+        assert_eq!(error_response["error"], "invalid_grant");
+        assert_eq!(
+            error_response["error_description"],
+            "The authorization code is invalid or expired."
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_google_callback_mocked() {
+        // Create a mock server
+        let server = MockServer::start();
+
+        // Mock the OIDC discovery document
+        let _discovery_mock = server.mock(|when, then| {
+            when.method("GET").path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "token_endpoint": server.url("/token"),
+                "jwks_uri": server.url("/jwks")
+            }));
+        });
+
+        // Mock an error response from Google token endpoint
+        let _token_mock = server.mock(|when, then| {
+            when.method("POST").path("/token");
+            then.status(400)
+                .json_body(json!({ "error": "invalid_grant", "error_description": "The authorization code is invalid or expired." }));
+        });
+
+        // Create a test config
+        let test_config = OIDCProviderConfig {
+            client_id: "test_client_id".to_string(),
+            client_secret: "test_client_secret".to_string(),
+            redirect_uri: "https://example.com/callback".to_string(),
+            discovery_url: server.url("/.well-known/openid-configuration"),
+        };
+
+        // Create app with handler and test config
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(test_config))
+                .service(web::resource("/callback").route(web::get().to(google_callback_handler))),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/callback?code=invalid_code")
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+
+        // Deserialize the response body as JSON
+        let body = test::read_body(resp).await;
+        let error_response: serde_json::Value =
+            serde_json::from_slice(&body).expect("Failed to parse error response");
+
+        // Assert the error message is returned from Google
+        assert_eq!(error_response["error"], "invalid_grant");
+        assert_eq!(
+            error_response["error_description"],
+            "The authorization code is invalid or expired."
+        );
+    }
 }

--- a/tests/oidc_integration_tests.rs
+++ b/tests/oidc_integration_tests.rs
@@ -1,10 +1,11 @@
 use actix_web::body::BoxBody;
-use actix_web::{test, web, App};
+use actix_web::{http::StatusCode, test, web, App}; // Importing StatusCode from actix_web
+use rustify_auth::core::oidc_providers::OIDCProviderConfig; // Importing OIDCProviderConfig
 use rustify_auth::endpoints::{google_callback_handler, google_login_handler};
 use serde_json::{json, Value};
 use std::env;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate}; // Import the env module to set environment variables
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[actix_web::test]
 async fn test_google_login_redirect() {
@@ -22,10 +23,15 @@ async fn test_google_login_redirect() {
         env::var("GOOGLE_REDIRECT_URI").unwrap()
     );
 
+    // Initialize the app with the login handler route
     let app =
         test::init_service(App::new().route("/auth/google", web::get().to(google_login_handler)))
             .await;
+
+    // Simulate a request to the Google login endpoint
     let req = test::TestRequest::get().uri("/auth/google").to_request();
+
+    // Call the service and check if it returns a redirection
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_redirection());
 }
@@ -43,6 +49,14 @@ async fn test_google_callback_mocked() {
     // Start a mock server to simulate Google OAuth endpoints
     let mock_server = MockServer::start().await;
 
+    // Mock the OIDC discovery document endpoint
+    Mock::given(path("/.well-known/openid-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "token_endpoint": format!("{}/token", mock_server.uri())
+        })))
+        .mount(&mock_server)
+        .await;
+
     // Mock the Google OAuth token exchange endpoint with a JSON error response
     Mock::given(path("/token"))
         .and(method("POST"))
@@ -53,11 +67,23 @@ async fn test_google_callback_mocked() {
         .mount(&mock_server)
         .await;
 
-    // Initialize the test app with your Google callback handler
-    let app = test::init_service(App::new().route(
-        "/auth/google/callback",
-        web::get().to(google_callback_handler),
-    ))
+    // Create a test OIDCProviderConfig pointing to the mock server
+    let test_config = OIDCProviderConfig {
+        client_id: "mock_google_client_id".to_string(),
+        client_secret: "mock_google_client_secret".to_string(),
+        redirect_uri: "http://localhost:8080/auth/google/callback".to_string(),
+        discovery_url: format!("{}/.well-known/openid-configuration", mock_server.uri()),
+    };
+
+    // Initialize the test app with your Google callback handler and test config
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(test_config)) // Inject the test config
+            .route(
+                "/auth/google/callback",
+                web::get().to(google_callback_handler),
+            ),
+    )
     .await;
 
     // Simulate a request to the callback endpoint with a mock authorization code
@@ -65,8 +91,19 @@ async fn test_google_callback_mocked() {
         .uri("/auth/google/callback?code=mock_auth_code")
         .to_request();
 
-    // Call and read the response body as text first
-    let resp_body = test::call_and_read_body(&app, req).await;
+    // Call and read the response body
+    let resp = test::call_service(&app, req).await;
+
+    // Assert the response status is BadRequest (400)
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    let resp_body = test::read_body(resp).await;
+
+    // Log the raw response for debugging
+    println!(
+        "Raw response body: {:?}",
+        String::from_utf8_lossy(&resp_body)
+    );
 
     // Try to parse the response body as JSON
     if let Ok(json_resp) = serde_json::from_slice::<Value>(&resp_body) {
@@ -78,17 +115,11 @@ async fn test_google_callback_mocked() {
                 "The OAuth client was not found."
             );
         } else {
-            // If it's not an error, check the token fields
-            assert_eq!(json_resp["access_token"], "mock_access_token");
-            assert_eq!(json_resp["id_token"], "mock_id_token");
-            assert_eq!(json_resp["expires_in"], 3600);
-            assert_eq!(json_resp["scope"], "email");
+            panic!("Expected an error, but received a successful response.");
         }
     } else {
-        // If parsing as JSON fails, handle the raw response and assert it
+        // If parsing as JSON fails, show raw response for debugging
         let raw_resp = String::from_utf8_lossy(&resp_body);
-        assert!(raw_resp.contains("Error from Google OAuth"));
-        assert!(raw_resp.contains("\"error\": \"invalid_client\""));
-        assert!(raw_resp.contains("\"error_description\": \"The OAuth client was not found.\""));
+        panic!("Failed to parse JSON response. Raw response: {}", raw_resp);
     }
 }


### PR DESCRIPTION
- Added 'google_login_handler' to initiate Google OAuth flow by redirecting to Google's authorization URL.
- Added 'google_callback_handler' to handle the callback from Google and exchange the authorization code for tokens.
- Implemented request and response structs for token exchange ('GoogleAuthCodeRequest', 'GoogleTokenResponse', and 'GoogleIdTokenClaims').
- Integrated OIDC discovery document to dynamically fetch token endpoints.
- Added unit tests for successful and error scenarios in 'google_callback_handler'.
- Included mocking of Google OAuth responses using 'httpmock' and Actix Web tests.

and

fix: resolve missing imports for OIDCProviderConfig and StatusCode in OIDC integration tests

- Imported OIDCProviderConfig from rustify_auth::core::oidc_providers.
- Replaced http::StatusCode with actix_web::http::StatusCode.
- Updated test_google_callback_mocked to use proper OIDC configuration and mock server.
- Added more detailed error logging for easier debugging of test failures.