### PR TITLE
feat: Add device code expiration cleanup and fix type mismatch in cle…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,16 @@
-use crate::auth::mock::{MockSessionManager, MockUserAuthenticator};
 use crate::config::OAuthConfig;
 use crate::core::authorization::AuthorizationCodeFlow;
 use crate::core::authorization::MockTokenGenerator;
+use crate::core::device_flow::{start_device_code_cleanup, DeviceCodeStore};
 use crate::core::token::{InMemoryTokenStore, RedisTokenStore};
 use crate::endpoints::register::ClientStore;
 use crate::routes::init_routes;
 use crate::storage::memory::MemoryCodeStore;
 use actix_web::{web, App, HttpServer};
 use security::tls::configure_tls;
+use std::sync::RwLock;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-use std::sync::RwLock;
 
 pub mod auth;
 pub mod auth_middleware;
@@ -53,6 +52,13 @@ pub fn create_auth_code_flow() -> Arc<Mutex<AuthorizationCodeFlow>> {
 
     // Wrap in Arc<Mutex<AuthorizationCodeFlow>> for shared ownership and mutable access
     Arc::new(Mutex::new(auth_code_flow))
+}
+
+// Function to start device code cleanup, exported for library users
+pub fn start_cleanup_task(device_code_store: Arc<DeviceCodeStore>) {
+    // Convert Arc<DeviceCodeStore> into web::Data<DeviceCodeStore>
+
+    start_device_code_cleanup(device_code_store.into());
 }
 
 #[actix_web::main]


### PR DESCRIPTION
…anup task

- Implemented 'cleanup_expired_codes' method in 'DeviceCodeStore' to remove expired device codes.
- Added a periodic cleanup task using 'actix_web::rt::spawn' to invoke the cleanup method every 60 seconds.
- Resolved type mismatch in 'start_cleanup_task' by converting 'Arc<DeviceCodeStore>' to 'web::Data<DeviceCodeStore>' using '.into()' for proper integration with Actix Web's data management.