### PR TITLE
feat(endpoints): add ActionMetadata in mod.rs and integrate into upda…

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -110,3 +110,22 @@ pub enum RegistrationError {
     InvalidRequest,
     InvalidGrant,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActionMetadata {
+    pub action_timestamp: String,
+    pub performed_by: String,
+    pub client_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClientDeleteResponse {
+    pub message: String,
+    pub metadata: ActionMetadata,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClientUpdateResponse {
+    pub message: String,
+    pub metadata: ActionMetadata,
+}

--- a/src/endpoints/delete.rs
+++ b/src/endpoints/delete.rs
@@ -1,10 +1,12 @@
 use crate::auth::rbac::rbac_check;
 use crate::core::token::TokenStore;
+use crate::core::types::{ActionMetadata, ClientUpdateResponse as CoreClientUpdateResponse};
 use crate::endpoints::register::Client as RegisterClient;
 use crate::endpoints::update::Client as UpdateClient;
 use crate::endpoints::update::ClientStore;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 

--- a/src/endpoints/update.rs
+++ b/src/endpoints/update.rs
@@ -1,7 +1,9 @@
 use crate::core::token::InMemoryTokenStore;
 use crate::core::token::TokenStore;
+use crate::core::types::{ActionMetadata, ClientUpdateResponse as CoreClientUpdateResponse};
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::RwLock;


### PR DESCRIPTION
…te and delete responses

- Define ActionMetadata struct in src/endpoints/mod.rs for shared use
- Extend ClientUpdateResponse and ClientDeleteResponse to include ActionMetadata
- Update both delete and update handlers to populate metadata with action details (timestamp, user, client_id)